### PR TITLE
docs: add typescript link to readme

### DIFF
--- a/qlik.dev/tutorials/platform-operations/README.md
+++ b/qlik.dev/tutorials/platform-operations/README.md
@@ -6,7 +6,8 @@ The current coverage of each tutorial is shown below:
 
 | Example/ Docs covered      | [Create a tenant](https://qlik.dev/manage/platform-operations/create-a-tenant) | [Configure a tenant](https://qlik.dev/manage/platform-operations/configure-a-tenant) | [Add interactive user](https://qlik.dev/manage/platform-operations/add-an-interactive-user-to-a-tenant) | [Add themes & extensions](https://qlik.dev/manage/platform-operations/add-custom-themes-and-extensions) | [Deploy Qlik Sense app](https://qlik.dev/manage/platform-operations/deploy-content-to-a-tenant) | [Deploy automation](https://qlik.dev/manage/platform-operations/deploy-automation-to-a-tenant) |
 | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |----------- |
-| [Qlik Python SDK](./sdk-python) | ✔ | ✔ | ✔ |  | ✔ |  |
+| [Qlik Platform SDK (Python)](./sdk-python) | ✔ | ✔ | ✔ |  | ✔ |  |
+| [Qlik Platform SDK (Typescript)](./sdk-typescript) | ✔ | ✔ | ✔ |  | ✔ |  |
 | [Qlik CLI (bash)](./cli-bash) | ✔ | ✔ | ✔ |  | ✔ |  |
 | [curl (bash)](./curl-bash) | ✔ | ✔ | ✔ |  | ✔ |  |
 | [API Collection (Postman)](./api-collection) | ✔ | ✔ | ✔ |  | ✔ | ✔ |


### PR DESCRIPTION
Add typescript links to readme on platform ops examples